### PR TITLE
removed bwarelabs.com RPC

### DIFF
--- a/.origintrail_noderc_example
+++ b/.origintrail_noderc_example
@@ -7,7 +7,6 @@
                 "https://rpc-mumbai.maticvigil.com/",
                 "https://matic-mumbai.chainstacklabs.com",
                 "https://rpc-mumbai.matic.today",
-                "https://matic-testnet-archive-rpc.bwarelabs.com"
             ],
             "publicKey": "...",
             "privateKey": "..."


### PR DESCRIPTION
The "matic-testnet-archive-rpc.bwarelabs.com" RPC is down and has been since Nov 29, 2021 as far as I can find.